### PR TITLE
Parse move descriptions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,7 @@ name = "chess"
 version = "0.1.0"
 dependencies = [
  "itertools 0.7.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "nom 4.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -18,6 +19,28 @@ dependencies = [
  "either 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
+[[package]]
+name = "memchr"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "nom"
+version = "4.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "memchr 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "version_check"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
 [metadata]
 "checksum either 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3be565ca5c557d7f59e7cfcf1844f9e3033650c929c6566f511e8005f205c1d0"
 "checksum itertools 0.7.8 (registry+https://github.com/rust-lang/crates.io-index)" = "f58856976b776fedd95533137617a02fb25719f40e7d9b01c7043cd65474f450"
+"checksum memchr 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2efc7bc57c883d4a4d6e3246905283d8dae951bb3bd32f49d6ef297f546e1c39"
+"checksum nom 4.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "22293d25d3f33a8567cc8a1dc20f40c7eeb761ce83d0fcca059858580790cac3"
+"checksum version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "914b1a6776c4c929a602fafd8bc742e06365d4bcbe48c30f9cca5824f70dc9dd"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,3 +15,4 @@ path = "src/bin/main.rs"
 
 [dependencies]
 itertools = "0.7.8"
+nom = "4.2.2"

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -1,5 +1,6 @@
 use std::io;
 
+use chess::move_description::MoveDescription;
 use chess::new_game;
 
 fn main() {
@@ -20,11 +21,8 @@ fn main() {
         }
 
         println!("{}'s move.", game.state.player);
-        for (i, m0ve) in moves.iter().enumerate() {
-            println!("{}: {}", i + 1, m0ve);
-        }
 
-        println!("Enter 1..{} ('q' quits)", moves.len());
+        println!("Please enter a move, or 'q' quits.");
 
         io::stdin().read_line(&mut buf).unwrap();
 
@@ -33,16 +31,15 @@ fn main() {
             break;
         }
 
-        match buf.trim().parse::<usize>() {
-            Ok(i) => {
-                if i <= moves.len() && i > 0 {
-                    game = moves.into_iter().nth(i - 1).expect("checked index").next;
-                } else {
-                    println!("Please enter a number between 1 and {}.", moves.len());
+        match MoveDescription::parse(buf.trim()) {
+            Ok(move_description) => match move_description.match_moves(moves) {
+                Some(m0ve) => {
+                    game = m0ve.next;
                 }
-            }
+                None => println!("Can't make that move!"),
+            },
             Err(_) => {
-                println!("Please enter a number between 1 and {}.", moves.len());
+                println!("Sorry, that doesn't describe a move!");
             }
         }
 

--- a/src/board.rs
+++ b/src/board.rs
@@ -1,6 +1,6 @@
 use itertools::iproduct;
 
-use crate::{Piece::*, Player, Player::*, Pos, Square};
+use crate::{piece::Piece::*, player::Player, player::Player::*, pos::Pos, square::Square};
 
 pub type BoardMatrix = Vec<Square>;
 

--- a/src/game.rs
+++ b/src/game.rs
@@ -6,8 +6,8 @@ pub struct Game {
     pub state: State,
 }
 
-impl Game {
-    pub fn initial() -> Game {
+impl Default for Game {
+    fn default() -> Self {
         let board = Board::initial();
         let player = White;
         let state = State { board, player };

--- a/src/game.rs
+++ b/src/game.rs
@@ -1,5 +1,16 @@
+use crate::board::Board;
+use crate::player::Player::*;
 use crate::state::State;
 
 pub struct Game {
     pub state: State,
+}
+
+impl Game {
+    pub fn initial() -> Game {
+        let board = Board::initial();
+        let player = White;
+        let state = State { board, player };
+        Game { state }
+    }
 }

--- a/src/game.rs
+++ b/src/game.rs
@@ -2,6 +2,7 @@ use crate::board::Board;
 use crate::player::Player::*;
 use crate::state::State;
 
+#[derive(Clone)]
 pub struct Game {
     pub state: State,
 }

--- a/src/game.rs
+++ b/src/game.rs
@@ -2,7 +2,6 @@ use crate::board::Board;
 use crate::player::Player::*;
 use crate::state::State;
 
-#[derive(Clone)]
 pub struct Game {
     pub state: State,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,26 +8,9 @@ pub mod pos;
 pub mod square;
 pub mod state;
 
-use crate::{
-    board::Board, game::Game, piece::Piece, player::Player, player::Player::*, pos::Pos,
-    square::Square, state::State,
-};
+use crate::game::Game;
 
 /// Initial game.
 pub fn new_game() -> Game {
-    let board = Board::initial();
-    let player = White;
-    let state = State { board, player };
-    Game { state }
-}
-
-#[cfg(test)]
-mod test {
-    use super::*;
-
-    #[test]
-    fn test_new_game_starts_white() {
-        let game = new_game();
-        assert_eq!(game.state.player, White);
-    }
+    Game::initial()
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,5 +12,5 @@ use crate::game::Game;
 
 /// Initial game.
 pub fn new_game() -> Game {
-    Game::initial()
+    Game::default()
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod board;
 pub mod game;
 pub mod m0ve;
+pub mod move_description;
 pub mod piece;
 pub mod player;
 pub mod pos;

--- a/src/m0ve.rs
+++ b/src/m0ve.rs
@@ -1,7 +1,6 @@
 use crate::{game::Game, pos::Pos};
 use std::fmt;
 
-#[derive(Clone)]
 pub struct Move {
     pub index: (Pos, Pos),
     pub next: Game,

--- a/src/m0ve.rs
+++ b/src/m0ve.rs
@@ -1,6 +1,7 @@
 use crate::{game::Game, pos::Pos};
 use std::fmt;
 
+#[derive(Clone)]
 pub struct Move {
     pub index: (Pos, Pos),
     pub next: Game,

--- a/src/move_description.rs
+++ b/src/move_description.rs
@@ -1,0 +1,38 @@
+use crate::piece::Piece;
+use crate::pos::Pos;
+use std::result::Result;
+
+mod parser;
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct MoveDescription {
+    pub src_piece: Piece,
+    pub dst_pos: Pos,
+}
+
+pub fn parse_move_description(input: &str) -> Result<MoveDescription, String> {
+    match parser::move_description(input) {
+        Ok((_, md)) => Ok(md),
+        Err(e) => Err(format!("parsing error: {:?}", e)),
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_parse_move_description() {
+        assert_eq!(
+            parse_move_description("Ke2"),
+            Ok(MoveDescription {
+                src_piece: Piece::King,
+                dst_pos: Pos { file: 4, rank: 1 }
+            })
+        );
+        assert_eq!(
+            parse_move_description("Ze2"),
+            Err(r#"parsing error: Error(Code("Ze2", Alt))"#.to_string())
+        );
+    }
+}

--- a/src/move_description.rs
+++ b/src/move_description.rs
@@ -62,7 +62,7 @@ mod test {
     }
 
     fn test_game() -> Game {
-        Game::initial()
+        Game::default()
     }
 
     #[test]

--- a/src/move_description.rs
+++ b/src/move_description.rs
@@ -10,10 +10,12 @@ pub struct MoveDescription {
     pub dst_pos: Pos,
 }
 
-pub fn parse_move_description(input: &str) -> Result<MoveDescription, String> {
-    match parser::move_description(input) {
-        Ok((_, md)) => Ok(md),
-        Err(e) => Err(format!("parsing error: {:?}", e)),
+impl MoveDescription {
+    pub fn parse(input: &str) -> Result<MoveDescription, String> {
+        match parser::move_description(input) {
+            Ok((_, md)) => Ok(md),
+            Err(e) => Err(format!("parsing error: {:?}", e)),
+        }
     }
 }
 
@@ -24,14 +26,14 @@ mod test {
     #[test]
     fn test_parse_move_description() {
         assert_eq!(
-            parse_move_description("Ke2"),
+            MoveDescription::parse("Ke2"),
             Ok(MoveDescription {
                 src_piece: Piece::King,
                 dst_pos: Pos { file: 4, rank: 1 }
             })
         );
         assert_eq!(
-            parse_move_description("Ze2"),
+            MoveDescription::parse("Ze2"),
             Err(r#"parsing error: Error(Code("Ze2", Alt))"#.to_string())
         );
     }

--- a/src/move_description.rs
+++ b/src/move_description.rs
@@ -15,7 +15,7 @@ impl MoveDescription {
     pub fn parse(input: &str) -> Result<MoveDescription, String> {
         match parser::move_description(input) {
             Ok((ref rem, ref _md)) if !rem.is_empty() => {
-                Err(format!("parsing error: extra characters"))
+                Err("parsing error: extra characters".to_string())
             }
             Ok((_remaining, md)) => Ok(md),
             Err(e) => Err(format!("parsing error: {:?}", e)),

--- a/src/move_description.rs
+++ b/src/move_description.rs
@@ -68,7 +68,7 @@ mod test {
     #[test]
     fn test_match_moves() {
         let mut game = test_game();
-        for desc in vec!["e3", "e6", "Ke2", "e5", "Kd3", "e4"] {
+        for desc in &["e3", "e6", "Ke2", "e5", "Kd3", "e4"] {
             let next_moves = game.state.gen_moves();
             let move_desc = MoveDescription::parse(desc).unwrap();
             game = move_desc.match_moves(next_moves).unwrap().next;

--- a/src/move_description.rs
+++ b/src/move_description.rs
@@ -22,7 +22,7 @@ impl MoveDescription {
     pub fn match_moves(&self, moves: Vec<Move>) -> Option<Move> {
         for m0ve in moves {
             if self.match_move(&m0ve) {
-                return Some(m0ve.clone());
+                return Some(m0ve);
             }
         }
         None

--- a/src/move_description.rs
+++ b/src/move_description.rs
@@ -1,3 +1,4 @@
+use crate::m0ve::Move;
 use crate::piece::Piece;
 use crate::pos::Pos;
 use std::result::Result;
@@ -17,14 +18,36 @@ impl MoveDescription {
             Err(e) => Err(format!("parsing error: {:?}", e)),
         }
     }
+
+    pub fn match_moves(&self, moves: Vec<Move>) -> Option<Move> {
+        for m0ve in moves {
+            if self.match_move(&m0ve) {
+                return Some(m0ve.clone());
+            }
+        }
+        None
+    }
+
+    fn match_move(&self, m0ve: &Move) -> bool {
+        let (_from, to) = m0ve.index;
+        let dst_piece = m0ve
+            .next
+            .state
+            .board
+            .piece_at(to)
+            .map(|(_player, piece)| piece);
+        self.dst_pos == to && Some(self.src_piece) == dst_piece
+    }
 }
 
 #[cfg(test)]
 mod test {
     use super::*;
+    use crate::game::Game;
+    use crate::player::Player;
 
     #[test]
-    fn test_parse_move_description() {
+    fn test_parse() {
         assert_eq!(
             MoveDescription::parse("Ke2"),
             Ok(MoveDescription {
@@ -35,6 +58,32 @@ mod test {
         assert_eq!(
             MoveDescription::parse("Ze2"),
             Err(r#"parsing error: Error(Code("Ze2", Alt))"#.to_string())
+        );
+    }
+
+    fn test_game() -> Game {
+        Game::initial()
+    }
+
+    #[test]
+    fn test_match_moves() {
+        let mut game = test_game();
+        for desc in vec!["e3", "e6", "Ke2", "e5", "Kd3", "e4"] {
+            let next_moves = game.state.gen_moves();
+            let move_desc = MoveDescription::parse(desc).unwrap();
+            game = move_desc.match_moves(next_moves).unwrap().next;
+        }
+
+        let d3 = MoveDescription::parse("d3").unwrap();
+        assert_eq!(
+            game.state.board.piece_at(d3.dst_pos),
+            Some((Player::White, Piece::King))
+        );
+
+        let e4 = MoveDescription::parse("e4").unwrap();
+        assert_eq!(
+            game.state.board.piece_at(e4.dst_pos),
+            Some((Player::Black, Piece::Pawn))
         );
     }
 }

--- a/src/move_description.rs
+++ b/src/move_description.rs
@@ -14,7 +14,10 @@ pub struct MoveDescription {
 impl MoveDescription {
     pub fn parse(input: &str) -> Result<MoveDescription, String> {
         match parser::move_description(input) {
-            Ok((_, md)) => Ok(md),
+            Ok((ref rem, ref _md)) if !rem.is_empty() => {
+                Err(format!("parsing error: extra characters"))
+            }
+            Ok((_remaining, md)) => Ok(md),
             Err(e) => Err(format!("parsing error: {:?}", e)),
         }
     }
@@ -58,6 +61,10 @@ mod test {
         assert_eq!(
             MoveDescription::parse("Ze2"),
             Err(r#"parsing error: Error(Code("Ze2", Alt))"#.to_string())
+        );
+        assert_eq!(
+            MoveDescription::parse("Ke2junk"),
+            Err(r#"parsing error: extra characters"#.to_string())
         );
     }
 

--- a/src/move_description/parser.rs
+++ b/src/move_description/parser.rs
@@ -1,0 +1,120 @@
+use crate::move_description::MoveDescription;
+use crate::piece::Piece;
+use crate::pos::Pos;
+use nom::{alt, do_parse, named, tag, value};
+
+named!(
+    piece<&str, Piece>,
+    alt!(
+        value!(Piece::King, tag!("K")) |
+        value!(Piece::Pawn, tag!(""))
+    )
+);
+
+named!(
+    rank<&str, u8>,
+    alt!(
+        value!(0, tag!("1")) |
+        value!(1, tag!("2")) |
+        value!(2, tag!("3")) |
+        value!(3, tag!("4")) |
+        value!(4, tag!("5")) |
+        value!(5, tag!("6")) |
+        value!(6, tag!("7")) |
+        value!(7, tag!("8"))
+    )
+);
+
+named!(
+    file<&str, u8>,
+    alt!(
+        value!(0, tag!("a")) |
+        value!(1, tag!("b")) |
+        value!(2, tag!("c")) |
+        value!(3, tag!("d")) |
+        value!(4, tag!("e")) |
+        value!(5, tag!("f")) |
+        value!(6, tag!("g")) |
+        value!(7, tag!("h"))
+    )
+);
+
+named!(
+    pos<&str, Pos>,
+    do_parse!(
+        file: file >>
+        rank: rank >>
+        (Pos { file, rank })
+    )
+);
+
+named!(
+    #[doc="
+        Parses a movement description.
+    "],
+    pub move_description<&str, MoveDescription>,
+    do_parse!(
+        src_piece: piece >>
+        dst_pos: pos >>
+        (MoveDescription { src_piece, dst_pos })
+    )
+);
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use nom::Context::Code;
+    use nom::Err::Error;
+    use nom::ErrorKind;
+
+    #[test]
+    fn parse_piece() {
+        assert_eq!(piece("Ke4"), Ok(("e4", Piece::King)));
+        assert_eq!(piece("e4"), Ok(("e4", Piece::Pawn)));
+    }
+
+    #[test]
+    fn parse_rank() {
+        assert_eq!(rank("4e2"), Ok(("e2", 3)));
+        assert_eq!(rank("41e2"), Ok(("1e2", 3)));
+        assert_eq!(rank("0e2"), Err(Error(Code("0e2", ErrorKind::Alt))));
+        assert_eq!(rank("9e2"), Err(Error(Code("9e2", ErrorKind::Alt))));
+    }
+
+    #[test]
+    fn parse_file() {
+        assert_eq!(file("e2"), Ok(("2", 4)));
+        assert_eq!(file("i2"), Err(Error(Code("i2", ErrorKind::Alt))));
+    }
+
+    #[test]
+    fn parse_pos() {
+        assert_eq!(pos("e2"), Ok(("", Pos { file: 4, rank: 1 })));
+        assert_eq!(pos("a1"), Ok(("", Pos { file: 0, rank: 0 })));
+        assert_eq!(pos("h7"), Ok(("", Pos { file: 7, rank: 6 })));
+    }
+
+    #[test]
+    fn parse_move_description() {
+        assert_eq!(
+            move_description("Ke2"),
+            Ok((
+                "",
+                MoveDescription {
+                    src_piece: Piece::King,
+                    dst_pos: Pos { file: 4, rank: 1 }
+                }
+            ))
+        );
+        assert_eq!(
+            move_description("a1"),
+            Ok((
+                "",
+                MoveDescription {
+                    src_piece: Piece::Pawn,
+                    dst_pos: Pos { file: 0, rank: 0 }
+                }
+            ))
+        );
+    }
+}

--- a/src/piece.rs
+++ b/src/piece.rs
@@ -1,4 +1,4 @@
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Piece {
     Pawn,
     King,


### PR DESCRIPTION
parse user input for moves such as `Ke2`, `e5`; match these "move descriptions" with generated moves.

for now:
- does not recognize capture notation
- does not accept disambiguation (e.g., `de5` for `d pawn captures e5`)
- does not calculate if a given move description needs disambiguation (just takes the first valid move it generated)

```
8        ♚
7♟ ♟ ♟ ♟ ♟ ♟ ♟ ♟
6
5
4
3
2♙ ♙ ♙ ♙ ♙ ♙ ♙ ♙
1        ♔
 A B C D E F G H
White's move.
Please enter a move, or 'q' quits.
> e3
```

```
8        ♚
7♟ ♟ ♟ ♟ ♟ ♟ ♟ ♟
6
5
4
3        ♙
2♙ ♙ ♙ ♙   ♙ ♙ ♙
1        ♔
 A B C D E F G H
```