### PR TITLE
En passant

### DIFF
--- a/src/an.rs
+++ b/src/an.rs
@@ -43,7 +43,7 @@ fn file(input: &str) -> IResult<&str, u8> {
     ))(input)
 }
 
-fn pos(input: &str) -> IResult<&str, Pos> {
+pub fn pos(input: &str) -> IResult<&str, Pos> {
     let (input, file) = file(input)?;
     let (input, rank) = rank(input)?;
     Ok((input, Pos { file, rank }))

--- a/src/fen.rs
+++ b/src/fen.rs
@@ -1,14 +1,16 @@
+use crate::an::pos;
 use crate::board::Board;
 use crate::piece::Piece;
 use crate::player::Player;
+use crate::pos::Pos;
 use crate::state::State;
 
 use nom::branch::alt;
 use nom::bytes::complete::tag;
-use nom::character::complete::space1;
-use nom::combinator::value;
+use nom::character::complete::{alpha1, space1};
+use nom::combinator::{map, value};
 use nom::error::ErrorKind;
-use nom::multi::separated_list;
+use nom::multi::{many1, separated_list};
 use nom::Err;
 use nom::IResult;
 
@@ -99,12 +101,21 @@ fn row(input: &str) -> IResult<&str, Vec<SquareBuilder>> {
     Ok((input, row))
 }
 
-// For now, this is just whose turn it is.
-fn extra_state(input: &str) -> IResult<&str, Player> {
+fn current_player(input: &str) -> IResult<&str, Player> {
     alt((
         value(Player::White, tag("w")),
         value(Player::Black, tag("b")),
     ))(input)
+}
+
+fn en_passant_pos(input: &str) -> IResult<&str, Option<Pos>> {
+    alt((value(None, tag("-")), map(pos, |p: Pos| Some(p))))(input)
+}
+
+// TODO
+fn castling(input: &str) -> IResult<&str, ()> {
+    let (input, _res) = many1(alt((tag("-"), alpha1)))(input)?;
+    Ok((input, ()))
 }
 
 pub fn piece_to_fen(player_piece: (Player, Piece)) -> String {
@@ -154,10 +165,21 @@ pub fn fen(input: &str) -> IResult<&str, State> {
     );
 
     let (input, _) = space1(input)?;
-    let (input, player) = extra_state(input)?;
+    let (input, player) = current_player(input)?;
+    let (input, _) = space1(input)?;
+    let (input, _castling) = castling(input)?;
+    let (input, _) = space1(input)?;
+    let (input, en_passant) = en_passant_pos(input)?;
 
     let board = Board::from_squares(squares.as_slice());
-    Ok((input, State { board, player }))
+    Ok((
+        input,
+        State {
+            board,
+            player,
+            en_passant,
+        },
+    ))
 }
 
 #[cfg(test)]
@@ -203,7 +225,7 @@ mod test {
 
     #[test]
     fn test_parse_valid_fen() {
-        let input = "r1b1kb1r/pppppppp/8/8/4P3/8/PPPP1PPP/R1B1KB1R b";
+        let input = "r1b1kb1r/pppppppp/8/8/4P3/8/PPPP1PPP/R1B1KB1R b - e3";
         let state_res = fen(input);
         assert!(state_res.is_ok(), "able to parse fen");
         let (_rest, state) = state_res.unwrap();
@@ -212,6 +234,7 @@ mod test {
         assert_eq!(state.board.piece_at(e1), Some((Player::White, Piece::King)));
         assert_eq!(state.board.piece_at(h2), Some((Player::White, Piece::Pawn)));
         assert_eq!(state.board.piece_at(h7), Some((Player::Black, Piece::Pawn)));
+        assert_eq!(state.en_passant, Some(e3));
     }
 
     #[test]

--- a/src/fen.rs
+++ b/src/fen.rs
@@ -109,7 +109,7 @@ fn current_player(input: &str) -> IResult<&str, Player> {
 }
 
 fn en_passant_pos(input: &str) -> IResult<&str, Option<Pos>> {
-    alt((value(None, tag("-")), map(pos, |p: Pos| Some(p))))(input)
+    alt((value(None, tag("-")), map(pos, Some)))(input)
 }
 
 // TODO

--- a/src/game.rs
+++ b/src/game.rs
@@ -10,7 +10,11 @@ impl Default for Game {
     fn default() -> Self {
         let board = Board::initial();
         let player = White;
-        let state = State { board, player };
+        let state = State {
+            board,
+            player,
+            en_passant: None,
+        };
         Game { state }
     }
 }

--- a/src/state.rs
+++ b/src/state.rs
@@ -8,6 +8,7 @@ use itertools::Itertools;
 pub struct State {
     pub board: Board,
     pub player: Player,
+    pub en_passant: Option<Pos>,
 }
 
 impl State {
@@ -17,6 +18,7 @@ impl State {
         let next_move_state = State {
             board: self.board.clone(),
             player: self.player.other(),
+            en_passant: None,
         };
 
         for from_pos in self.board.coords() {
@@ -63,14 +65,33 @@ impl State {
         let next_state = State {
             player: self.player,
             board: self.board.move_piece(from_pos, to_pos),
+            en_passant: None,
         };
         !next_state.in_check()
+    }
+
+    fn en_passant_pos(&self, from: Pos, to: Pos) -> Option<Pos> {
+        match self.board.piece_at(from) {
+            Some((_, Pawn)) if from.abs_diff(to).rank == 2 => {
+                let en_passant_rank = if from.rank > to.rank {
+                    from.rank - 1
+                } else {
+                    from.rank + 1
+                };
+                Some(Pos {
+                    rank: en_passant_rank,
+                    file: from.file,
+                })
+            }
+            _ => None,
+        }
     }
 
     fn build_move(&self, from: Pos, to: Pos) -> Move {
         let next_state = State {
             board: self.board.move_piece(from, to),
             player: self.player.other(),
+            en_passant: self.en_passant_pos(from, to),
         };
         Move {
             index: (from, to),
@@ -226,6 +247,14 @@ mod test {
     use crate::piece::Piece;
     use crate::pos::*;
 
+    fn simple_state(board: Board, player: Player) -> State {
+        State {
+            board: board,
+            player: player,
+            en_passant: None,
+        }
+    }
+
     fn test_board() -> Board {
         Board::initial()
     }
@@ -235,7 +264,7 @@ mod test {
         // piece at c4. E.g., the queen on this board:
         // https://lichess.org/analysis/standard/8/1k6/8/8/2QK4/8/8/8_w_-_-
         let piece_str = piece_to_fen((Player::White, piece));
-        let (_, state) = fen(format!("8/1k6/8/8/2{}K4/8/8/8 w", piece_str).as_str()).unwrap();
+        let (_, state) = fen(format!("8/1k6/8/8/2{}K4/8/8/8 w - -", piece_str).as_str()).unwrap();
         state.board
     }
 
@@ -244,7 +273,7 @@ mod test {
         // piece at c4. E.g., the queen on this board:
         // https://lichess.org/analysis/standard/8/1k6/8/8/2Q5/3K4/8/8/8_w_-_-
         let piece_str = piece_to_fen((Player::White, piece));
-        let (_, state) = fen(format!("8/1k6/8/8/2{}5/3K4/8/8 w", piece_str).as_str()).unwrap();
+        let (_, state) = fen(format!("8/1k6/8/8/2{}5/3K4/8/8 w - -", piece_str).as_str()).unwrap();
         state.board
     }
 
@@ -252,14 +281,8 @@ mod test {
     fn test_can_move_pseudo() {
         let board = test_board();
 
-        let white_move = State {
-            board: board.clone(),
-            player: White,
-        };
-        let black_move = State {
-            board: board.clone(),
-            player: Black,
-        };
+        let white_move = simple_state(board.clone(), White);
+        let black_move = simple_state(board.clone(), Black);
 
         assert!(white_move.can_move_pseudo(e2, e3));
         assert!(!white_move.can_move_pseudo(a1, a3));
@@ -271,10 +294,7 @@ mod test {
     fn test_rook_moves() {
         let board = test_simple_board_for_piece_lateral_king(Piece::Rook);
 
-        let white_move = State {
-            board,
-            player: White,
-        };
+        let white_move = simple_state(board, White);
 
         assert!(white_move.can_move(c4, c1));
         assert!(white_move.can_move(c4, c7));
@@ -286,10 +306,7 @@ mod test {
     fn test_bishop_moves() {
         let board = test_simple_board_for_piece_diagonal_king(Piece::Bishop);
 
-        let white_move = State {
-            board,
-            player: White,
-        };
+        let white_move = simple_state(board, White);
 
         assert!(white_move.can_move(c4, d5));
         assert!(white_move.can_move(c4, e6));
@@ -303,10 +320,7 @@ mod test {
     fn test_queen_diagonal_moves() {
         let board = test_simple_board_for_piece_diagonal_king(Piece::Queen);
 
-        let white_move = State {
-            board,
-            player: White,
-        };
+        let white_move = simple_state(board, White);
 
         assert!(white_move.can_move(c4, d5));
         assert!(white_move.can_move(c4, e6));
@@ -320,10 +334,7 @@ mod test {
     fn test_queen_lateral_moves() {
         let board = test_simple_board_for_piece_lateral_king(Piece::Queen);
 
-        let white_move = State {
-            board,
-            player: White,
-        };
+        let white_move = simple_state(board, White);
 
         assert!(white_move.can_move(c4, c1));
         assert!(white_move.can_move(c4, c7));
@@ -335,10 +346,7 @@ mod test {
     fn test_knight_moves() {
         let board = test_simple_board_for_piece_lateral_king(Piece::Knight);
 
-        let white_move = State {
-            board,
-            player: White,
-        };
+        let white_move = simple_state(board, White);
 
         let valid_moves = vec![b6, a5, a3, b2, d2, e3, e5, d6];
         for pos in white_move.board.coords().iter() {
@@ -352,28 +360,49 @@ mod test {
 
     #[test]
     fn test_in_check() {
-        let (_, not_in_check_state) = fen("8/8/8/8/8/pkp5/8/PKP5 w").unwrap();
+        let (_, not_in_check_state) = fen("8/8/8/8/8/pkp5/8/PKP5 w - -").unwrap();
         assert!(!not_in_check_state.in_check());
 
-        let (_, in_check_state_1) = fen("8/8/8/8/8/1kp5/p7/PKP5 w").unwrap();
+        let (_, in_check_state_1) = fen("8/8/8/8/8/1kp5/p7/PKP5 w - -").unwrap();
         assert!(in_check_state_1.in_check());
 
-        let (_, in_check_state_2) = fen("8/8/8/8/8/pk6/P1p5/1KP5 b").unwrap();
+        let (_, in_check_state_2) = fen("8/8/8/8/8/pk6/P1p5/1KP5 b - -").unwrap();
         assert!(in_check_state_2.in_check());
     }
 
     #[test]
-    fn test_two_square_advance() {
-        let (_, initial_state) = fen("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w").unwrap();
+    fn test_one_square_pawn_advance() {
+        let (_, initial_state) = fen("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w - -").unwrap();
+        assert!(initial_state.can_move(e2, e3));
+
+        let next_state = initial_state.build_move(e2, e3).next;
+        assert_eq!(next_state.en_passant, None);
+
+        let (_, one_e4) = fen("rnbqkbnr/pppppppp/8/8/4P3/8/PPPP1PPP/RNBQKBNR b - -").unwrap();
+        assert!(one_e4.can_move(e7, e6));
+
+        let next_state = one_e4.build_move(e7, e6).next;
+        assert_eq!(next_state.en_passant, None);
+    }
+
+    #[test]
+    fn test_two_square_pawn_advance() {
+        let (_, initial_state) = fen("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w - -").unwrap();
         assert!(initial_state.can_move(e2, e4));
 
-        let (_, one_e4) = fen("rnbqkbnr/pppppppp/8/8/4P3/8/PPPP1PPP/RNBQKBNR b").unwrap();
+        let next_state = initial_state.build_move(e2, e4).next;
+        assert_eq!(next_state.en_passant, Some(e3));
+
+        let (_, one_e4) = fen("rnbqkbnr/pppppppp/8/8/4P3/8/PPPP1PPP/RNBQKBNR b - -").unwrap();
         assert!(one_e4.can_move(e7, e5));
 
-        let (_, blocking) = fen("rnbqk1nr/pppp1ppp/4p3/8/4P3/b2P4/PPP2PPP/RNBQKBNR w").unwrap();
+        let next_state = one_e4.build_move(e7, e5).next;
+        assert_eq!(next_state.en_passant, Some(e6));
+
+        let (_, blocking) = fen("rnbqk1nr/pppp1ppp/4p3/8/4P3/b2P4/PPP2PPP/RNBQKBNR w - -").unwrap();
         assert!(!blocking.can_move(a2, a4));
 
-        let (_, blocking2) = fen("rnbqk1nr/pppp1ppp/8/3Pp3/4P3/b7/PPP2PPP/RNBQKBNR b").unwrap();
+        let (_, blocking2) = fen("rnbqk1nr/pppp1ppp/8/3Pp3/4P3/b7/PPP2PPP/RNBQKBNR b - -").unwrap();
         assert!(!blocking2.can_move(d7, d5));
     }
 }

--- a/src/state.rs
+++ b/src/state.rs
@@ -271,8 +271,8 @@ mod test {
 
     fn simple_state(board: Board, player: Player) -> State {
         State {
-            board: board,
-            player: player,
+            board,
+            player,
             en_passant: None,
         }
     }


### PR DESCRIPTION
Fixes #12

this made the `build_move` function quite a bit more complicated, which is maybe inevitable. it now has two more things to figure out: are we capturing en passant (which is unique in that it removes a piece from the board that is not a target of the move) and also, did we just add an en passant target (pawn two square advance).

my favorite part of this is how easy it was to add en passant parsing to the fen parser! i added a dummy `castling` parser (which in fen comes before en passant) just so valid fen would still parse correctly.