### PR TITLE
Move disambiguation

### DIFF
--- a/src/algebraic_notation.rs
+++ b/src/algebraic_notation.rs
@@ -50,7 +50,53 @@ pub fn pos(input: &str) -> IResult<&str, Pos> {
     Ok((input, Pos { file, rank }))
 }
 
-pub fn simple(input: &str) -> IResult<&str, MoveDescription> {
+fn simple_disambiguate_all(input: &str) -> IResult<&str, MoveDescription> {
+    let (input, src_piece) = piece(input)?;
+    let (input, src_file) = file(input)?;
+    let (input, src_rank) = rank(input)?;
+    let (input, dst_pos) = pos(input)?;
+    Ok((
+        input,
+        MoveDescription::Simple {
+            src_piece,
+            src_rank: Some(src_rank),
+            src_file: Some(src_file),
+            dst_pos,
+        },
+    ))
+}
+
+fn simple_disambiguate_rank(input: &str) -> IResult<&str, MoveDescription> {
+    let (input, src_piece) = piece(input)?;
+    let (input, src_rank) = rank(input)?;
+    let (input, dst_pos) = pos(input)?;
+    Ok((
+        input,
+        MoveDescription::Simple {
+            src_piece,
+            src_rank: Some(src_rank),
+            src_file: None,
+            dst_pos,
+        },
+    ))
+}
+
+fn simple_disambiguate_file(input: &str) -> IResult<&str, MoveDescription> {
+    let (input, src_piece) = piece(input)?;
+    let (input, src_file) = file(input)?;
+    let (input, dst_pos) = pos(input)?;
+    Ok((
+        input,
+        MoveDescription::Simple {
+            src_piece,
+            src_rank: None,
+            src_file: Some(src_file),
+            dst_pos,
+        },
+    ))
+}
+
+fn simple_no_disambiguation(input: &str) -> IResult<&str, MoveDescription> {
     let (input, src_piece) = piece(input)?;
     let (input, dst_pos) = pos(input)?;
     Ok((
@@ -62,6 +108,15 @@ pub fn simple(input: &str) -> IResult<&str, MoveDescription> {
             dst_pos,
         },
     ))
+}
+
+pub fn simple(input: &str) -> IResult<&str, MoveDescription> {
+    alt((
+        simple_disambiguate_all,
+        simple_disambiguate_rank,
+        simple_disambiguate_file,
+        simple_no_disambiguation,
+    ))(input)
 }
 
 fn castle(input: &str) -> IResult<&str, MoveDescription> {
@@ -175,6 +230,33 @@ mod test {
                 src_rank: None,
                 src_file: None,
                 dst_pos: e2,
+            })
+        );
+        assert_eq!(
+            parse_algebraic_notation("Bdb8"),
+            Ok(MoveDescription::Simple {
+                src_piece: Piece::Bishop,
+                src_rank: None,
+                src_file: Some(3),
+                dst_pos: b8,
+            })
+        );
+        assert_eq!(
+            parse_algebraic_notation("R1a3"),
+            Ok(MoveDescription::Simple {
+                src_piece: Piece::Rook,
+                src_rank: Some(0),
+                src_file: None,
+                dst_pos: a3,
+            })
+        );
+        assert_eq!(
+            parse_algebraic_notation("Qh4e1"),
+            Ok(MoveDescription::Simple {
+                src_piece: Piece::Queen,
+                src_rank: Some(3),
+                src_file: Some(7),
+                dst_pos: e1,
             })
         );
         assert_eq!(

--- a/src/algebraic_notation.rs
+++ b/src/algebraic_notation.rs
@@ -53,7 +53,15 @@ pub fn pos(input: &str) -> IResult<&str, Pos> {
 pub fn simple(input: &str) -> IResult<&str, MoveDescription> {
     let (input, src_piece) = piece(input)?;
     let (input, dst_pos) = pos(input)?;
-    Ok((input, MoveDescription::Simple { src_piece, dst_pos }))
+    Ok((
+        input,
+        MoveDescription::Simple {
+            src_piece,
+            src_rank: None,
+            src_file: None,
+            dst_pos,
+        },
+    ))
 }
 
 fn castle(input: &str) -> IResult<&str, MoveDescription> {
@@ -138,7 +146,9 @@ mod test {
                 "",
                 MoveDescription::Simple {
                     src_piece: Piece::King,
-                    dst_pos: e2
+                    src_rank: None,
+                    src_file: None,
+                    dst_pos: e2,
                 }
             ))
         );
@@ -148,7 +158,9 @@ mod test {
                 "",
                 MoveDescription::Simple {
                     src_piece: Piece::Pawn,
-                    dst_pos: a1
+                    src_rank: None,
+                    src_file: None,
+                    dst_pos: a1,
                 }
             ))
         );
@@ -160,6 +172,8 @@ mod test {
             parse_algebraic_notation("Ke2"),
             Ok(MoveDescription::Simple {
                 src_piece: Piece::King,
+                src_rank: None,
+                src_file: None,
                 dst_pos: e2,
             })
         );

--- a/src/board.rs
+++ b/src/board.rs
@@ -11,7 +11,7 @@ pub type BoardMatrix = Vec<Square>;
 const NSIZE: u8 = 8;
 
 /// 3x3 board
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct Board {
     inner: BoardMatrix,
 }

--- a/src/m0ve.rs
+++ b/src/m0ve.rs
@@ -1,11 +1,13 @@
 use crate::{castles::Castleside, pos::Pos, state::State};
 use std::fmt;
 
+#[derive(PartialEq, Debug)]
 pub enum Action {
     Simple { from: Pos, to: Pos },
     Castle { castleside: Castleside },
 }
 
+#[derive(PartialEq, Debug)]
 pub struct Move {
     pub action: Action,
     pub next: State,

--- a/src/move_description.rs
+++ b/src/move_description.rs
@@ -37,19 +37,15 @@ impl MoveDescription {
                     dst_pos,
                 },
             ) => {
+                if src_file.is_some() && src_file != &Some(from.file) {
+                    return false;
+                }
+
+                if src_rank.is_some() && src_rank != &Some(from.rank) {
+                    return false;
+                }
+
                 let dst_piece = m0ve.next.board.piece_at(*to).map(|(_, piece)| piece);
-
-                if let Some(incl_src_file) = src_file {
-                    if incl_src_file != &from.file {
-                        return false;
-                    }
-                }
-
-                if let Some(incl_src_rank) = src_rank {
-                    if incl_src_rank != &from.rank {
-                        return false;
-                    }
-                }
 
                 dst_pos == to && Some(*src_piece) == dst_piece
             }

--- a/src/move_description.rs
+++ b/src/move_description.rs
@@ -5,8 +5,15 @@ use crate::pos::Pos;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum MoveDescription {
-    Simple { src_piece: Piece, dst_pos: Pos },
-    Castle { castleside: Castleside },
+    Simple {
+        src_piece: Piece,
+        src_rank: Option<u8>,
+        src_file: Option<u8>,
+        dst_pos: Pos,
+    },
+    Castle {
+        castleside: Castleside,
+    },
 }
 
 impl MoveDescription {
@@ -21,7 +28,15 @@ impl MoveDescription {
 
     fn match_move(&self, m0ve: &Move) -> bool {
         match (&m0ve.action, self) {
-            (Action::Simple { from: _, to }, MoveDescription::Simple { src_piece, dst_pos }) => {
+            (
+                Action::Simple { from: _, to },
+                MoveDescription::Simple {
+                    src_file: _,
+                    src_rank: _,
+                    src_piece,
+                    dst_pos,
+                },
+            ) => {
                 let dst_piece = m0ve.next.board.piece_at(*to).map(|(_, piece)| piece);
                 dst_pos == to && Some(*src_piece) == dst_piece
             }

--- a/src/move_description.rs
+++ b/src/move_description.rs
@@ -20,9 +20,9 @@ impl MoveDescription {
     pub fn match_moves(&self, moves: Vec<Move>) -> Option<Move> {
         let matched: Vec<Move> = moves.into_iter().filter(|m| self.match_move(m)).collect();
         if matched.len() == 1 {
-            return matched.into_iter().next();
+            matched.into_iter().next()
         } else {
-            return None;
+            None
         }
     }
 

--- a/src/move_description.rs
+++ b/src/move_description.rs
@@ -32,7 +32,7 @@ impl MoveDescription {
                 Action::Simple { from, to },
                 MoveDescription::Simple {
                     src_file,
-                    src_rank: _,
+                    src_rank,
                     src_piece,
                     dst_pos,
                 },
@@ -44,6 +44,13 @@ impl MoveDescription {
                         return false;
                     }
                 }
+
+                if let Some(incl_src_rank) = src_rank {
+                    if incl_src_rank != &from.rank {
+                        return false;
+                    }
+                }
+
                 dst_pos == to && Some(*src_piece) == dst_piece
             }
             (
@@ -95,6 +102,34 @@ mod test {
             src_rank: None,
             src_piece: Piece::Knight,
             dst_pos: d5,
+        };
+        let matched = desc.match_moves(moves);
+        assert_ne!(matched, None);
+    }
+
+    #[test]
+    fn test_match_moves_needs_disambiguating_rank() {
+        let (_, state) = fen("8/3k4/8/1N6/8/1N6/3K4/8 w - - 0 1").unwrap();
+        let moves = state.gen_moves();
+        let desc = MoveDescription::Simple {
+            src_file: None,
+            src_rank: None,
+            src_piece: Piece::Knight,
+            dst_pos: d4,
+        };
+        let matched = desc.match_moves(moves);
+        assert_eq!(matched, None);
+    }
+
+    #[test]
+    fn test_match_moves_has_disambiguating_rank() {
+        let (_, state) = fen("8/3k4/8/1N6/8/1N6/3K4/8 w - - 0 1").unwrap();
+        let moves = state.gen_moves();
+        let desc = MoveDescription::Simple {
+            src_file: None,
+            src_rank: Some(2),
+            src_piece: Piece::Knight,
+            dst_pos: d4,
         };
         let matched = desc.match_moves(moves);
         assert_ne!(matched, None);

--- a/src/state.rs
+++ b/src/state.rs
@@ -4,7 +4,7 @@ use crate::{
 };
 use itertools::Itertools;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct State {
     pub board: Board,
     pub player: Player,


### PR DESCRIPTION
Fixes #27 

e.g.:

```sh
cargo run -- -i "8/1k6/8/8/8/7R/1K6/R7 w - - 0 1" play

8                
7  ♚             
6                
5                
4                
3              ♖ 
2  ♔             
1♖               
 A B C D E F G H 
White's move.
Please enter a move, or 'q' quits.
Ra3
Can't make that move!
```

You would need to use `Raa3`, or `R3a3`, identifying which rook to move to `a3`.

Or: try to move the corner queen to `e4` in this queen triangle:

```sh
cargo run -- -i "2k5/8/8/8/7Q/8/1K6/4Q2Q w - - 0 1" play
```